### PR TITLE
make: Support 'existing' and 'updated' action modifiers

### DIFF
--- a/docs/architecture/decisions/0004-semantics-of-updated-action-modifier.md
+++ b/docs/architecture/decisions/0004-semantics-of-updated-action-modifier.md
@@ -1,0 +1,23 @@
+# 4. Semantics of `updated` action modifier
+
+Date: 2022-07-06
+
+## Status
+
+Accepted
+
+## Context
+
+Jam's language documentation does not have a detailed specification describing what an updated target is. Replicating Jam's behavior is not possible since the `updated` action modifier is inconsistent when the source has dependents other than the action target.
+
+Ham requires a stricter definition of an updated target, both for end-users and for development.
+
+## Decision
+
+An updated target is one that is newer than the **action target**. In the action invocation `Action <target> : <sources>`, the time is compared against `<target>`, _not_ one or more of `<sources>` dependents. A source that is being made is always updated by definition. Having multiple targets in an `updated` action is an error.
+
+## Consequences
+
+This definition ensures that a target always "sees" when a source is updated. For instance, say `oldTarget` and `newTarget` both use a source in an updated action. If a source has a single definition of being updated based on it's dependencies, either `oldTarget` would not get the source, or `newTarget` would despite it not being updated relative to it. This is both unreliable, and breaks the principle that parents/siblings should not be able to affect a target's build.
+
+Because the time is compared against the action target, this means the behavior with multiple actions is unclear. Ham chooses to avoid confusion by throwing an error, but there are other options such as comparing against the newest/oldest target. It's possible that other features, such as parameters to action modifiers, could enable different behavior in the future.

--- a/docs/architecture/decisions/0005-actions-without-targets.md
+++ b/docs/architecture/decisions/0005-actions-without-targets.md
@@ -1,0 +1,19 @@
+# 5. Actions without targets
+
+Date: 2022-07-06
+
+## Status
+
+Accepted
+
+## Context
+
+Actions do special actions with their target list, such as using the variable scope of the first target, comparing against the target with `together` and `updated`, etc. An action without a target can't be invoked via dependencies. Currently there are no restrictions on the number of targets passed to an action.
+
+## Decision
+
+Passing zero targets to an action should be an error.
+
+## Consequences
+
+Helps catch bugs, as actions without targets are useless and error-prone.

--- a/src/behavior/Behavior.cpp
+++ b/src/behavior/Behavior.cpp
@@ -17,17 +17,20 @@ Behavior::Behavior(Compatibility compatibility)
 	: fEchoTrailingSpace(ECHO_NO_TRAILING_SPACE),
 	  fPathRootReplacerSlash(PATH_ROOT_REPLACER_SLASH_AVOID_DUPLICATE),
 	  fBrokenSubscriptJoin(NO_BROKEN_SUBSCRIPT_JOIN),
-	  fJoinCaseOperator(JOIN_AFTER_CASE_OPERATOR)
+	  fJoinCaseOperator(JOIN_AFTER_CASE_OPERATOR),
+	  fErrorUpdatedSource(ERROR_INDEPENDENT_UPDATED)
 {
 	switch (compatibility) {
 		case COMPATIBILITY_JAM:
 			fEchoTrailingSpace = ECHO_TRAILING_SPACE;
 			fPathRootReplacerSlash = PATH_ROOT_REPLACER_SLASH_ALWAYS;
 			fBrokenSubscriptJoin = BROKEN_SUBSCRIPT_JOIN;
+			fErrorUpdatedSource = WARN_INDEPENDENT_UPDATED;
 			break;
 		case COMPATIBILITY_BOOST_JAM:
 			fBrokenSubscriptJoin = BROKEN_SUBSCRIPT_JOIN;
 			fJoinCaseOperator = JOIN_BEFORE_CASE_OPERATOR;
+			fErrorUpdatedSource = WARN_INDEPENDENT_UPDATED;
 			break;
 		case COMPATIBILITY_HAM_1:
 			break;

--- a/src/behavior/Behavior.hpp
+++ b/src/behavior/Behavior.hpp
@@ -120,6 +120,20 @@ class Behavior
 		JOIN_AFTER_CASE_OPERATOR
 	};
 
+	enum ErrorUpdatedSource {
+		/**
+		 * Error when an independent source is passed to a RuleActions::UPDATED
+		 * action
+		 */
+		ERROR_INDEPENDENT_UPDATED,
+
+		/**
+		 * Warning when an independent source is passed to a
+		 * RuleActions::UPDATED action
+		 */
+		WARN_INDEPENDENT_UPDATED
+	};
+
   public:
 	Behavior(Compatibility compatibility);
 
@@ -136,12 +150,17 @@ class Behavior
 		return fBrokenSubscriptJoin;
 	}
 	JoinCaseOperator GetJoinCaseOperator() const { return fJoinCaseOperator; }
+	ErrorUpdatedSource GetErrorUpdatedSource() const
+	{
+		return fErrorUpdatedSource;
+	}
 
   private:
 	EchoTrailingSpace fEchoTrailingSpace;
 	PathRootReplacerSlash fPathRootReplacerSlash;
 	BrokenSubscriptJoin fBrokenSubscriptJoin;
 	JoinCaseOperator fJoinCaseOperator;
+	ErrorUpdatedSource fErrorUpdatedSource;
 };
 
 } // namespace ham::behavior

--- a/src/make/Processor.cpp
+++ b/src/make/Processor.cpp
@@ -825,6 +825,18 @@ Processor::_BuildCommand(data::RuleActionsCall* actionCall)
 
 	auto numTargets = actionCall->Targets().size();
 
+	// Actions must have at least one target (ADR 5)
+	//
+	// TODO: This is a redundant check because there shouldn't be a way to
+	// actually call an action without a target. This needs to be implemented
+	// somewhere in parsing.
+	if (numTargets == 0) {
+		std::stringstream error{};
+		error << "Error: Action " << actionCall->Actions()->RuleName()
+			  << " was called with no targets";
+		throw MakeException(error.str());
+	}
+
 	// Updated actions cannot have multiple targets (ADR 4)
 	if (isUpdatedAction && numTargets > 1) {
 		std::stringstream error{};

--- a/src/make/Processor.cpp
+++ b/src/make/Processor.cpp
@@ -753,9 +753,10 @@ Processor::_BindActionTargets(
 	const bool isExistingAction = flags & data::RuleActions::EXISTING;
 	const bool isUpdatedAction = flags & data::RuleActions::UPDATED;
 
-	const data::TargetList& targets = actionCall->Targets();
+	const data::TargetList& targets =
+		isSources ? actionCall->SourceTargets() : actionCall->Targets();
 
-	const Target* primaryTarget = *targets.begin();
+	const Target* primaryTarget = *actionCall->Targets().begin();
 	const MakeTarget* primaryMakeTarget = _GetMakeTarget(primaryTarget, true);
 
 	for (const auto target : targets) {

--- a/src/make/Processor.cpp
+++ b/src/make/Processor.cpp
@@ -823,6 +823,18 @@ Processor::_BuildCommand(data::RuleActionsCall* actionCall)
 	const bool isExistingAction = flags & data::RuleActions::EXISTING;
 	const bool isUpdatedAction = flags & data::RuleActions::UPDATED;
 
+	auto numTargets = actionCall->Targets().size();
+
+	// Updated actions cannot have multiple targets (ADR 4)
+	if (isUpdatedAction && numTargets > 1) {
+		std::stringstream error{};
+		error << "Error: Action " << actionCall->Actions()->RuleName()
+			  << " has 'updated' modifier and must be passed exactly 1 target, "
+				 "but was passed "
+			  << numTargets;
+		throw MakeException(error.str());
+	}
+
 	// create a variable domain for the built-in variables (the numbered ones
 	// and "<" and ">")
 	data::VariableDomain builtInVariables;

--- a/src/make/Processor.cpp
+++ b/src/make/Processor.cpp
@@ -797,9 +797,12 @@ Processor::_BindActionTargets(
 
 			// A source is updated if:
 			// - It is being made, or
-			// - It is newer than the target
-			bool updated = makeTarget->GetFate() == MakeTarget::MAKE
-				|| primaryMakeTarget->GetOriginalTime() < makeTarget->GetTime();
+			// - It is newer than the primary target, and
+			// - It is not a pseudotarget
+			bool updated = !_IsPseudoTarget(makeTarget)
+				&& (makeTarget->GetFate() == MakeTarget::MAKE
+					|| primaryMakeTarget->GetOriginalTime()
+						< makeTarget->GetTime());
 			if (isUpdatedAction && !updated)
 				continue;
 		}

--- a/src/make/Processor.cpp
+++ b/src/make/Processor.cpp
@@ -778,12 +778,14 @@ Processor::_BindActionTargets(
 
 				// Sources to UPDATED actions must be in the dependency
 				// tree
-				//
-				// TODO: Jam includes independent targets in UPDATED
-				// actions, so this should be made compatibility
-				// behavior.
-				if (isSources && isUpdatedAction) {
+				if (isSources && isUpdatedAction)
 					warning << " in an 'updated' action";
+
+				bool errorOnIndependentUpdated =
+					fEvaluationContext.GetBehavior().GetErrorUpdatedSource()
+					== behavior::Behavior::ERROR_INDEPENDENT_UPDATED;
+
+				if (isSources && isUpdatedAction && errorOnIndependentUpdated) {
 					throw MakeException(warning.str());
 				} else {
 					_PrintWarning(warning.str());

--- a/src/make/Processor.cpp
+++ b/src/make/Processor.cpp
@@ -852,13 +852,13 @@ Processor::_BuildCommand(data::RuleActionsCall* actionsCall)
 	data::VariableDomain builtInVariables;
 
 	StringList boundTargets;
-	_BindActionTargets(actionsCall, false, boundTargets);
+	_BindActionsTargets(actionsCall, false, boundTargets);
 	builtInVariables.Set("1", boundTargets);
 	builtInVariables.Set("<", boundTargets);
 	const bool targetsEmpty = boundTargets.IsEmpty();
 
 	StringList boundSourceTargets;
-	_BindActionTargets(actionsCall, true, boundSourceTargets);
+	_BindActionsTargets(actionsCall, true, boundSourceTargets);
 	builtInVariables.Set("2", boundSourceTargets);
 	builtInVariables.Set(">", boundSourceTargets);
 	const bool sourcesEmpty = boundSourceTargets.IsEmpty();

--- a/src/make/Processor.cpp
+++ b/src/make/Processor.cpp
@@ -753,13 +753,13 @@ Processor::_BindActionTargets(
 	const bool isExistingAction = flags & data::RuleActions::EXISTING;
 	const bool isUpdatedAction = flags & data::RuleActions::UPDATED;
 
-	const data::TargetList& targets =
+	const data::TargetList& targetList =
 		isSources ? actionCall->SourceTargets() : actionCall->Targets();
 
 	const Target* primaryTarget = *actionCall->Targets().begin();
 	const MakeTarget* primaryMakeTarget = _GetMakeTarget(primaryTarget, true);
 
-	for (const auto target : targets) {
+	for (const auto target : targetList) {
 		MakeTarget* makeTarget = _GetMakeTarget(target, true);
 
 		if (!makeTarget->IsBound()) {
@@ -799,11 +799,13 @@ Processor::_BindActionTargets(
 			// - It is being made, or
 			// - It is newer than the primary target, and
 			// - It is not a pseudotarget
-			bool updated = !_IsPseudoTarget(makeTarget)
-				&& (makeTarget->GetFate() == MakeTarget::MAKE
-					|| primaryMakeTarget->GetOriginalTime()
-						< makeTarget->GetTime());
-			if (isUpdatedAction && !updated)
+			bool isMake = makeTarget->GetFate() == MakeTarget::MAKE;
+			bool isNewer =
+				primaryMakeTarget->GetOriginalTime() < makeTarget->GetTime();
+			bool isUpdatedTarget =
+				!_IsPseudoTarget(makeTarget) && (isMake || isNewer);
+
+			if (isUpdatedAction && !isUpdatedTarget)
 				continue;
 		}
 

--- a/src/make/Processor.hpp
+++ b/src/make/Processor.hpp
@@ -122,12 +122,12 @@ class Processor
 	 * Create a list of bound paths from an actions targets. Depending on action
 	 * modifiers, may exclude certain targets.
 	 *
-	 * \param[in] actionCall action call to bind
+	 * \param[in] actionsCall actions call to bind
 	 * \param[in] isSources whether or not to bind the sources of the action
 	 * call \param[out] boundTargets list to append bound targets to
 	 */
-	void _BindActionTargets(
-		const data::RuleActionsCall* actionCall,
+	void _BindActionsTargets(
+		const data::RuleActionsCall* actionsCall,
 		const bool isSources,
 		StringList& boundTargets
 	);

--- a/src/make/Processor.hpp
+++ b/src/make/Processor.hpp
@@ -6,6 +6,7 @@
 #define HAM_CODE_PROCESSOR_HPP
 
 #include "code/EvaluationContext.hpp"
+#include "data/RuleActions.hpp"
 #include "data/StringList.hpp"
 #include "data/TargetPool.hpp"
 #include "data/VariableDomain.hpp"
@@ -116,6 +117,20 @@ class Processor
 	 * \param[in] makeTarget
 	 */
 	void _BindTarget(MakeTarget* makeTarget);
+
+	/**
+	 * Create a list of bound paths from an actions targets. Depending on action
+	 * modifiers, may exclude certain targets.
+	 *
+	 * \param[in] actionCall action call to bind
+	 * \param[in] isSources whether or not to bind the sources of the action
+	 * call \param[out] boundTargets list to append bound targets to
+	 */
+	void _BindActionTargets(
+		const data::RuleActionsCall* actionCall,
+		const bool isSources,
+		StringList& boundTargets
+	);
 
 	/**
 	 * Scans target with the kHeaderScanVariableName egrep pattern. If matches

--- a/testdata/make/ActionModifiers
+++ b/testdata/make/ActionModifiers
@@ -81,7 +81,7 @@ Depends all : target ;
 -
 #!file target missing
 ---
-# Updated modifier, all targets missing
+# Updated modifier, independent targets
 # target	- target
 # source1	- source (missing)
 # source2	- source (missing)
@@ -97,11 +97,12 @@ LOCATE on source1 = . ;
 LOCATE on source2 = . ;
 LOCATE on source3 = . ;
 
+NOTFILE source2 ;
 EchoAction target : source1 source2 source3 ;
 Depends all : target ;
+Depends target : source2 ;
 -
-#!file target
-./source1 ./source2 ./source3
+#!file target missing
 ---
 # Updated modifier, some targets updated
 # target	- target
@@ -128,7 +129,7 @@ Depends all : target ;
 Old
 #!file source1 2
 Source1
-#!file source2
+#!file source2 0
 Source2
 #!file source3 2
 Source3

--- a/testdata/make/ActionModifiers
+++ b/testdata/make/ActionModifiers
@@ -241,12 +241,18 @@ Source3
 Updated
 ---
 # Updated modifier, targets updated indirectly
-# oldTarget	- target (old)
-# newTarget - target (new)
-# source1	- source (directly updated)
-# source2	- source (directly not updated)
-# source3	- source (indirectly updated)
-# source4	- source (indirectly not updated)
+# oldTarget		- target (old)
+#  source1		- source (directly updated)
+#  source2		- source (directly not updated)
+#  gen			- source (missing, being made)
+#  newTarget	- target (new)
+#   source3		- source (indirectly updated, newer than both)
+#   source4		- source (indirectly updated, newer than target)
+#   source5		- source (indirectly not updated, older than target)
+# siblingTarget	- target (old)
+#  source6		- source (updated for sibling)
+# emptyTarget	- target
+#  pseudo		- source (pseudotarget)
 #!file Jamfile
 rule JoinFiles
 {
@@ -259,29 +265,67 @@ actions updated JoinFiles
 	echo "Updated" >> $(1)
 }
 
+actions GenSource
+{
+	echo Created $(1) > $(1)
+}
+
+NOTFILE pseudo ;
 LOCATE on newTarget = . ;
 LOCATE on oldTarget = . ;
-JoinFiles newTarget : source1 source2 source3 source4 ;
+LOCATE on siblingTarget = . ;
+LOCATE on emptyTarget = . ;
+LOCATE on gen = . ;
 
-Depends newTarget : source1 source2 ;
-Depends oldTarget : source3 source4 newTarget ;
-Depends all : oldTarget ;
+GenSource gen ;
 
+JoinFiles oldTarget
+		  : source1
+		   	source2
+		  	source3
+		  	source4
+		  	source5
+		  	source6
+		  	gen ;
+JoinFiles siblingTarget : source6 ;
+JoinFiles newTarget : source3 source4 source5 ;
+JoinFiles emptyTarget : pseudo ;
+
+Depends oldTarget : newTarget ;
+Depends all : oldTarget siblingTarget emptyTarget ;
+
+#!file siblingTarget 4
+Sibling
 #!file oldTarget 3
 Old
 #!file newTarget 1
 New
 #!file source1
 Source1
-#!file source2 1
+#!file source2 3
 Source2
-#!file source3 2
+#!file source3
 Source3
-#!file source4 3
+#!file source4 2
 Source4
+#!file source5 3
+Source5
+#!file source6 3
+Source6
 -
-#!file newTarget
+#!file oldTarget
 Source1
 Source3
+Source4
+Created gen
 Updated
+#!file siblingTarget
+Source6
+Updated
+#!file newTarget
+Source3
+Updated
+#!file emptyTarget missing
+#!file gen
+Created gen
 ---

--- a/testdata/make/ActionModifiers
+++ b/testdata/make/ActionModifiers
@@ -102,7 +102,33 @@ EchoAction target : source1 source2 source3 ;
 Depends all : target ;
 Depends target : source2 ;
 -
+#!error make
 #!file target missing
+---
+# Updated modifier, independent targets, compatibility
+# target	- target
+# source1	- source (missing)
+# source2	- source (missing)
+# source3	- source (missing)
+#!file Jamfile
+#!compat jam boost !ham
+actions updated EchoAction
+{
+	echo $(2) >> $(1)
+}
+
+LOCATE on target = . ;
+LOCATE on source1 = . ;
+LOCATE on source2 = . ;
+LOCATE on source3 = . ;
+
+NOTFILE source2 ;
+EchoAction target : source1 source2 source3 ;
+Depends all : target ;
+Depends target : source2 ;
+-
+#!file target
+./source1 ./source2 ./source3
 ---
 # Updated modifier, some targets updated
 # target	- target

--- a/testdata/make/ActionModifiers
+++ b/testdata/make/ActionModifiers
@@ -4,7 +4,7 @@
 #!multipleFiles
 ---
 # Don't include missing sources in 'existing' actions
-# target	- target (missing)
+# target	- target
 # source1	- source
 # source2	- source (missing)
 # source3	- source
@@ -31,7 +31,7 @@ Already exists
 ./source1 ./source3
 ---
 # Include all existing sources in 'existing' actions
-# target	- target (missing)
+# target	- target
 # source1	- source
 # source2	- source
 # source3	- source
@@ -60,7 +60,7 @@ Already exists
 ./source1 ./source2 ./source3
 ---
 # Don't run 'existing' actions without any existing sources
-# target	- target (missing)
+# target	- target
 # source1	- source (missing)
 # source2	- source (missing)
 # source3	- source (missing)
@@ -80,4 +80,135 @@ EchoAction target : source1 source2 source3 ;
 Depends all : target ;
 -
 #!file target missing
+---
+# Updated modifier, all targets missing
+# target	- target
+# source1	- source (missing)
+# source2	- source (missing)
+# source3	- source (missing)
+#!file Jamfile
+actions updated EchoAction
+{
+	echo $(2) >> $(1)
+}
+
+LOCATE on target = . ;
+LOCATE on source1 = . ;
+LOCATE on source2 = . ;
+LOCATE on source3 = . ;
+
+EchoAction target : source1 source2 source3 ;
+Depends all : target ;
+-
+#!file target
+./source1 ./source2 ./source3
+---
+# Updated modifier, some targets updated
+# target	- target
+# source1	- source (older)
+# source2	- source (newer)
+# source3	- source (older)
+#!file Jamfile
+rule JoinFiles
+{
+	Depends $(1) : $(2) ;
+}
+
+actions updated JoinFiles
+{
+	cat $(2) > $(1)
+	echo "Updated" >> $(1)
+}
+
+LOCATE on target = . ;
+JoinFiles target : source1 source2 source3 ;
+Depends all : target ;
+
+#!file target 1
+Old
+#!file source1 2
+Source1
+#!file source2
+Source2
+#!file source3 2
+Source3
+-
+#!file target
+Source2
+Updated
+---
+# Updated modifier, all targets updated
+# target	- target
+# source1	- source (newer)
+# source2	- source (newer)
+# source3	- source (newer)
+#!file Jamfile
+rule JoinFiles
+{
+	Depends $(1) : $(2) ;
+}
+
+actions updated JoinFiles
+{
+	cat $(2) > $(1)
+	echo "Updated" >> $(1)
+}
+
+LOCATE on target = . ;
+JoinFiles target : source1 source2 source3 ;
+Depends all : target ;
+
+#!file target 1
+Old
+#!file source1
+Source1
+#!file source2
+Source2
+#!file source3
+Source3
+-
+#!file target
+Source1
+Source2
+Source3
+Updated
+---
+# Updated modifier, no targets updated in an invocation
+# target	- target
+# source1	- source (older)
+# source2	- source (newer)
+# source3	- source (newer)
+#!file Jamfile
+rule JoinFiles
+{
+	Depends $(1) : $(2) ;
+}
+
+actions updated JoinFiles
+{
+	cat $(2) >> $(1)
+	echo "Updated" >> $(1)
+}
+
+LOCATE on target = . ;
+JoinFiles target : source1 ;
+JoinFiles target : source2 ;
+JoinFiles target : source3 ;
+Depends all : target ;
+
+#!file target 1
+Old
+#!file source1 2
+Source1
+#!file source2
+Source2
+#!file source3
+Source3
+-
+#!file target
+Old
+Source2
+Updated
+Source3
+Updated
 ---

--- a/testdata/make/ActionModifiers
+++ b/testdata/make/ActionModifiers
@@ -239,3 +239,48 @@ Updated
 Source3
 Updated
 ---
+# Updated modifier, targets updated indirectly
+# oldTarget	- target (old)
+# newTarget - target (new)
+# source1	- source (directly updated)
+# source2	- source (directly not updated)
+# source3	- source (indirectly updated)
+# source4	- source (indirectly not updated)
+#!file Jamfile
+rule JoinFiles
+{
+	Depends $(1) : $(2) ;
+}
+
+actions updated JoinFiles
+{
+	cat $(2) > $(1)
+	echo "Updated" >> $(1)
+}
+
+LOCATE on newTarget = . ;
+LOCATE on oldTarget = . ;
+JoinFiles newTarget : source1 source2 source3 source4 ;
+
+Depends newTarget : source1 source2 ;
+Depends oldTarget : source3 source4 newTarget ;
+Depends all : oldTarget ;
+
+#!file oldTarget 3
+Old
+#!file newTarget 1
+New
+#!file source1
+Source1
+#!file source2 1
+Source2
+#!file source3 2
+Source3
+#!file source4 3
+Source4
+-
+#!file newTarget
+Source1
+Source3
+Updated
+---

--- a/testdata/make/ActionModifiers
+++ b/testdata/make/ActionModifiers
@@ -317,7 +317,7 @@ Source6
 Source1
 Source3
 Source4
-Created gen
+Created ./gen
 Updated
 #!file siblingTarget
 Source6
@@ -327,5 +327,5 @@ Source3
 Updated
 #!file emptyTarget missing
 #!file gen
-Created gen
+Created ./gen
 ---

--- a/testdata/make/ActionModifiers
+++ b/testdata/make/ActionModifiers
@@ -1,0 +1,83 @@
+# Copyright 2022, Dominic Martinez, dom@dominicm.dev
+# Distributed under the terms of the MIT License.
+
+#!multipleFiles
+---
+# Don't include missing sources in 'existing' actions
+# target	- target (missing)
+# source1	- source
+# source2	- source (missing)
+# source3	- source
+#
+#!file Jamfile
+actions existing EchoExisting
+{
+	echo $(2) >> $(1)
+}
+
+LOCATE on target = . ;
+LOCATE on source1 = . ;
+LOCATE on source2 = . ;
+LOCATE on source3 = . ;
+
+EchoExisting target : source1 source2 source3 ;
+Depends all : target ;
+#!file source1
+Already exists
+#!file source3
+Already exists
+-
+#!file target
+./source1 ./source3
+---
+# Include all existing sources in 'existing' actions
+# target	- target (missing)
+# source1	- source
+# source2	- source
+# source3	- source
+#
+#!file Jamfile
+actions existing EchoExisting
+{
+	echo $(2) >> $(1)
+}
+
+LOCATE on target = . ;
+LOCATE on source1 = . ;
+LOCATE on source2 = . ;
+LOCATE on source3 = . ;
+
+EchoExisting target : source1 source2 source3 ;
+Depends all : target ;
+#!file source1
+Already exists
+#!file source2
+Already exists
+#!file source3
+Already exists
+-
+#!file target
+./source1 ./source2 ./source3
+---
+# Don't run 'existing' actions without any existing sources
+# target	- target (missing)
+# source1	- source (missing)
+# source2	- source (missing)
+# source3	- source (missing)
+#
+#!file Jamfile
+actions existing EchoAction
+{
+	echo $(2) >> $(1)
+}
+
+LOCATE on target = . ;
+LOCATE on source1 = . ;
+LOCATE on source2 = . ;
+LOCATE on source3 = . ;
+
+EchoAction target : source1 source2 source3 ;
+Depends all : target ;
+-
+#!file target missing
+---

--- a/testdata/make/ActionModifiers
+++ b/testdata/make/ActionModifiers
@@ -329,3 +329,30 @@ Updated
 #!file gen
 Created ./gen
 ---
+# Updated modifier, multiple targets
+# target1	- target
+# target2	- target
+# source	- source
+#!file Jamfile
+rule JoinFiles
+{
+	Depends $(1) : $(2) ;
+}
+
+actions updated JoinFiles
+{
+	cat $(2) >> $(1)
+	echo "Updated" >> $(1)
+}
+
+LOCATE on target1 = . ;
+LOCATE on target2 = . ;
+JoinFiles target1 target2 : source ;
+Depends all : target1 target2 ;
+
+#!file source
+Source
+-
+#!exception
+Error: Action JoinFiles has 'updated' modifier and must be passed exactly 1 target, but was passed 2
+---

--- a/testdata/make/ActionModifiers
+++ b/testdata/make/ActionModifiers
@@ -102,7 +102,8 @@ EchoAction target : source1 source2 source3 ;
 Depends all : target ;
 Depends target : source2 ;
 -
-#!error make
+#!exception
+using independent target source1 in an 'updated' action
 #!file target missing
 ---
 # Updated modifier, independent targets, compatibility


### PR DESCRIPTION
Closes #44 and #39 
- [x] Add support for 'existing' and 'updated' modifiers
- [x] Add tests for 'existing' modifier
- [x] Add tests for 'updated' modifier
- [x] Support indirectly updated dependencies
- [x] Add behavior for erroring with standalone updated targets
- [x] Add ADR for `updated` behavior
- [x] Add test for error on multiple targets with updated action