### PR TITLE
Refactor memory and lifetime management

### DIFF
--- a/src/code/BuiltInRules.cpp
+++ b/src/code/BuiltInRules.cpp
@@ -89,10 +89,6 @@ class MatchInstructions : public RuleInstructions
 		StringList result;
 		for (size_t i = 0; i < expressionCount; i++) {
 			RegExp regExp(expressions.ElementAt(i).ToCString());
-			if (!regExp.IsValid()) {
-				// TODO: Throw exception!
-				continue;
-			}
 
 			for (size_t k = 0; k < stringCount; k++) {
 				String string = strings.ElementAt(k);
@@ -138,8 +134,7 @@ class GlobInstructions : public RuleInstructions
 				patterns.ElementAt(k).ToCString(),
 				RegExp::PATTERN_TYPE_WILDCARD
 			);
-			if (regExp.IsValid())
-				regExps.push_back(regExp);
+			regExps.push_back(regExp);
 		}
 		size_t regExpCount = regExps.size();
 

--- a/src/code/Case.cpp
+++ b/src/code/Case.cpp
@@ -9,6 +9,8 @@
 #include "code/EvaluationContext.hpp"
 #include "data/RegExp.hpp"
 
+#include <iostream>
+
 namespace ham::code
 {
 
@@ -26,16 +28,16 @@ Case::Matches(EvaluationContext&, const StringList& value) const
 {
 	using data::RegExp;
 
-	RegExp regExp(fPattern.ToCString(), RegExp::PATTERN_TYPE_WILDCARD);
-	if (!regExp.IsValid()) {
-		// TODO: Throw exception!
+	try {
+		RegExp regExp(fPattern.ToCString(), RegExp::PATTERN_TYPE_WILDCARD);
+		String string = value.ElementAt(0);
+		RegExp::MatchResult match = regExp.Match(string.ToCString());
+		return match.HasMatched() && match.StartOffset() == 0
+			&& match.EndOffset() == string.Length();
+	} catch (const RegExp::Exception& e) {
+		std::cerr << e.what();
 		return false;
 	}
-
-	String string = value.ElementAt(0);
-	RegExp::MatchResult match = regExp.Match(string.ToCString());
-	return match.HasMatched() && match.StartOffset() == 0
-		&& match.EndOffset() == string.Length();
 }
 
 StringList

--- a/src/make/Processor.cpp
+++ b/src/make/Processor.cpp
@@ -549,8 +549,6 @@ Processor::_ScanForHeaders(MakeTarget* makeTarget)
 
 	// prepare the grep regular expression
 	data::RegExp regExp(scanPattern->ElementAt(0).ToCString());
-	if (!regExp.IsValid())
-		return;
 
 	// open the file
 	std::ifstream file(makeTarget->BoundPath().ToCString());

--- a/src/tests/RegExpTest.cpp
+++ b/src/tests/RegExpTest.cpp
@@ -57,32 +57,17 @@ class RegExpTest::Matches : public std::vector<std::pair<size_t, size_t>>
 void
 RegExpTest::Constructor()
 {
-	// default constructor
-	{
-		RegExp regExp;
-		HAM_TEST_VERIFY(!regExp.IsValid())
-		HAM_TEST_VERIFY(!regExp.Match("dummy").HasMatched())
-	}
-
 	// (const char*) constructor
 	{
 		RegExp regExp("dummy");
-		HAM_TEST_VERIFY(regExp.IsValid())
 		HAM_TEST_VERIFY(regExp.Match("dummy").HasMatched())
 	}
 
 	// copy constructor
 	{
-		RegExp regExp;
-		RegExp regExp2(regExp);
-		HAM_TEST_VERIFY(!regExp2.IsValid())
-		HAM_TEST_VERIFY(!regExp2.Match("dummy").HasMatched())
-	}
-
-	{
 		RegExp regExp("dummy");
 		RegExp regExp2(regExp);
-		HAM_TEST_VERIFY(regExp2.IsValid())
+		HAM_TEST_VERIFY(regExp.Match("dummy").HasMatched())
 		HAM_TEST_VERIFY(regExp2.Match("dummy").HasMatched())
 	}
 
@@ -141,12 +126,6 @@ RegExpTest::MatchRegularExpression()
 		// constructor
 		{
 			RegExp regExp(pattern, RegExp::PATTERN_TYPE_REGULAR_EXPRESSION);
-			HAM_TEST_ADD_INFO(
-				HAM_TEST_VERIFY(regExp.IsValid()),
-				"pattern: \"%s\"",
-				pattern
-			)
-
 			RegExp::MatchResult result = regExp.Match(string);
 			HAM_TEST_ADD_INFO(
 				HAM_TEST_EQUAL(
@@ -163,66 +142,6 @@ RegExpTest::MatchRegularExpression()
 		{
 			RegExp regExp0(pattern, RegExp::PATTERN_TYPE_REGULAR_EXPRESSION);
 			RegExp regExp(regExp0);
-			HAM_TEST_ADD_INFO(
-				HAM_TEST_VERIFY(regExp.IsValid()),
-				"pattern: \"%s\"",
-				pattern
-			)
-			RegExp::MatchResult result = regExp.Match(string);
-			HAM_TEST_ADD_INFO(
-				HAM_TEST_EQUAL(
-					match_result_to_vector(result),
-					matches.ToVector()
-				),
-				"pattern: \"%s\", string: \"%s\"",
-				pattern,
-				string
-			)
-		}
-
-		// SetPattern()
-		{
-			RegExp regExp;
-			HAM_TEST_ADD_INFO(
-				HAM_TEST_VERIFY(regExp.SetPattern(
-					pattern,
-					RegExp::PATTERN_TYPE_REGULAR_EXPRESSION
-				)),
-				"pattern: \"%s\"",
-				pattern
-			)
-			HAM_TEST_ADD_INFO(
-				HAM_TEST_VERIFY(regExp.IsValid()),
-				"pattern: \"%s\"",
-				pattern
-			)
-			RegExp::MatchResult result = regExp.Match(string);
-			HAM_TEST_ADD_INFO(
-				HAM_TEST_EQUAL(
-					match_result_to_vector(result),
-					matches.ToVector()
-				),
-				"pattern: \"%s\", string: \"%s\"",
-				pattern,
-				string
-			)
-		}
-
-		{
-			RegExp regExp("some pattern");
-			HAM_TEST_ADD_INFO(
-				HAM_TEST_VERIFY(regExp.SetPattern(
-					pattern,
-					RegExp::PATTERN_TYPE_REGULAR_EXPRESSION
-				)),
-				"pattern: \"%s\"",
-				pattern
-			)
-			HAM_TEST_ADD_INFO(
-				HAM_TEST_VERIFY(regExp.IsValid()),
-				"pattern: \"%s\"",
-				pattern
-			)
 			RegExp::MatchResult result = regExp.Match(string);
 			HAM_TEST_ADD_INFO(
 				HAM_TEST_EQUAL(
@@ -280,12 +199,6 @@ RegExpTest::MatchWildcard()
 		// constructor
 		{
 			RegExp regExp(pattern, RegExp::PATTERN_TYPE_WILDCARD);
-			HAM_TEST_ADD_INFO(
-				HAM_TEST_VERIFY(regExp.IsValid()),
-				"pattern: \"%s\"",
-				pattern
-			)
-
 			RegExp::MatchResult result = regExp.Match(string);
 			HAM_TEST_ADD_INFO(
 				HAM_TEST_EQUAL(
@@ -302,64 +215,6 @@ RegExpTest::MatchWildcard()
 		{
 			RegExp regExp0(pattern, RegExp::PATTERN_TYPE_WILDCARD);
 			RegExp regExp(regExp0);
-			HAM_TEST_ADD_INFO(
-				HAM_TEST_VERIFY(regExp.IsValid()),
-				"pattern: \"%s\"",
-				pattern
-			)
-			RegExp::MatchResult result = regExp.Match(string);
-			HAM_TEST_ADD_INFO(
-				HAM_TEST_EQUAL(
-					match_result_to_vector(result),
-					matches.ToVector()
-				),
-				"pattern: \"%s\", string: \"%s\"",
-				pattern,
-				string
-			)
-		}
-
-		// SetPattern()
-		{
-			RegExp regExp;
-			HAM_TEST_ADD_INFO(
-				HAM_TEST_VERIFY(
-					regExp.SetPattern(pattern, RegExp::PATTERN_TYPE_WILDCARD)
-				),
-				"pattern: \"%s\"",
-				pattern
-			)
-			HAM_TEST_ADD_INFO(
-				HAM_TEST_VERIFY(regExp.IsValid()),
-				"pattern: \"%s\"",
-				pattern
-			)
-			RegExp::MatchResult result = regExp.Match(string);
-			HAM_TEST_ADD_INFO(
-				HAM_TEST_EQUAL(
-					match_result_to_vector(result),
-					matches.ToVector()
-				),
-				"pattern: \"%s\", string: \"%s\"",
-				pattern,
-				string
-			)
-		}
-
-		{
-			RegExp regExp("some pattern");
-			HAM_TEST_ADD_INFO(
-				HAM_TEST_VERIFY(
-					regExp.SetPattern(pattern, RegExp::PATTERN_TYPE_WILDCARD)
-				),
-				"pattern: \"%s\"",
-				pattern
-			)
-			HAM_TEST_ADD_INFO(
-				HAM_TEST_VERIFY(regExp.IsValid()),
-				"pattern: \"%s\"",
-				pattern
-			)
 			RegExp::MatchResult result = regExp.Match(string);
 			HAM_TEST_ADD_INFO(
 				HAM_TEST_EQUAL(


### PR DESCRIPTION
Closes #62 
Closes #15 

- [ ]  Replace `Referenceable` with `shared_ptr`, which:
  - Allows for throwing exceptions without missing reference counts
  - Lets objects be `const`
- [ ] Replaces manual String classes with STL implementations