### PR TITLE
code: Don't absorb breaks in switch

### DIFF
--- a/src/code/Switch.cpp
+++ b/src/code/Switch.cpp
@@ -38,11 +38,6 @@ Switch::Evaluate(EvaluationContext& context)
 		if ((*it)->Matches(context, argument)) {
 			// found match -- execute the block
 			const StringList& result = (*it)->Evaluate(context);
-
-			// clear a break jump condition
-			if (context.GetJumpCondition() == JUMP_CONDITION_BREAK)
-				context.SetJumpCondition(JUMP_CONDITION_NONE);
-
 			return result;
 		}
 	}


### PR DESCRIPTION
Jam switches don't absorb breaks per the spec, and since switches can only execute a single statement anyway I don't see a reason to change that behavior.

This also fixes an infinite loop while parsing Haiku build files.